### PR TITLE
Docker support WIP (antidote is build in docker with the latest erlang)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:buster
+
+# Basic system stuff
+RUN apt-get update
+RUN apt-get install -y apt-transport-https
+
+# Install packages
+RUN apt-get -qy update && \
+    apt-get -qy install \
+             build-essential \
+             libssl-dev \
+             automake \
+             autoconf \
+             libncurses5-dev \
+             git \
+             curl
+
+SHELL ["/bin/bash", "-c"]
+# Install erlang
+RUN mkdir -p $HOME/bin && \
+    git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.9.0 && \
+    source $HOME/.asdf/asdf.sh && \
+    asdf plugin add erlang
+RUN source $HOME/.asdf/asdf.sh && \
+    asdf install erlang 25.0-rc2 || true
+
+ENV PATH="$HOME/bin:/root/.asdf/plugins/erlang/kerl-home/builds/asdf_25.0-rc2/release_25.0-rc2/bin:${PATH}"
+
+# Install rebar3
+RUN git clone https://github.com/erlang/rebar3.git && \
+    (cd rebar3 && ./bootstrap && mv _build/prod/bin/rebar3 $HOME/bin)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+build-docker-env:
+	docker build -t build-env-antidote .
+
+build-antidote: antidote
+	docker run --rm -it -v $(PWD):$(PWD) -w $(PWD) --name build build-env-antidote \
+			bash -c "make antidote-rel"
+
+antidote:
+	git clone https://github.com/AntidoteDB/antidote.git
+
+antidote-rel:
+	(cd antidote && cp ${HOME}/bin/rebar3 ./ && make all rel)
+
+start-jepsen-docker-env: jepsen
+	cd docker && bin/up.sh
+
+jepsen:
+	git clone https://github.com/jepsen-io/jepsen


### PR DESCRIPTION
Hi, I was curious about you jepsen tests for AntidoteDB and noticed that there is only support for lxc at the moment. 
I decided to have a look if I can easily integrate docker, with AntidoteDB that is build in the same base docker image, 
which is used in jepsen tests. I can see that in `db.clj` you expect antidote release to be present in `_build/default/rel/antidote`, however I couldn't find where do you clone and build it. It seems like some base makefile is missing, so I wonder if you can guide me how does your build step look like? 

update: It seems like local paths are hard-corded in `util.clj` at the moment, maybe there is a good way to parametrize it, so that proper paths could be used in both docker and lxc?