### PR TITLE
pn-counter: Jepsen workload, client, checker and Elixir client for AntidoteDB

### DIFF
--- a/beam.fuzz_dist/lib/fuzz_dist/telemetry.ex
+++ b/beam.fuzz_dist/lib/fuzz_dist/telemetry.ex
@@ -66,6 +66,46 @@ defmodule FuzzDist.Telemetry do
 
       * `%{}`
 
+  * `[:fuzz_dist, :pn_counter_read, :start]` - Executed on receipt of Jepsen :read operation.
+
+    #### Measurements
+
+      * `:system_time` - The system time
+
+    #### Metadata:
+
+      * `%{}`
+
+  * `[:fuzz_dist, :pn_counter_read, :stop]` - Executed on completion of read before return to Jepsen.
+
+    #### Measurements
+
+      * `:duration` - Duration of the read.
+
+    #### Metadata:
+
+      * :value - Value returned by read.
+
+  * `[:fuzz_dist, :pn_counter_add, :start]` - Executed on receipt of Jepsen :add operation.
+
+    #### Measurements
+
+      * `:system_time` - The system time
+
+    #### Metadata:
+
+      * `value`: - The value to be added
+
+  * `[:fuzz_dist, :pn_counter_add, :stop]` - Executed on completion of add before return to Jepsen.
+
+    #### Measurements
+
+      * `:duration` - Duration of the read.
+
+    #### Metadata:
+
+      * `%{}`
+
   * `[:fuzz_dist, :setup_primary, :start]` - Executed on receipt of Jepsen :setup_primary operation.
 
     #### Measurements
@@ -114,6 +154,10 @@ defmodule FuzzDist.Telemetry do
           [:fuzz_dist, :g_set_add, :stop],
           [:fuzz_dist, :g_set_read, :start],
           [:fuzz_dist, :g_set_read, :stop],
+          [:fuzz_dist, :pn_counter_add, :start],
+          [:fuzz_dist, :pn_counter_add, :stop],
+          [:fuzz_dist, :pn_counter_read, :start],
+          [:fuzz_dist, :pn_counter_read, :stop],
           [:fuzz_dist, :setup_primary, :start],
           [:fuzz_dist, :setup_primary, :stop]
         ],

--- a/jepsen.fuzz_dist/project.clj
+++ b/jepsen.fuzz_dist/project.clj
@@ -3,7 +3,8 @@
   :url "https://github.com/nurturenature"
   :license {:name "Licensed under the Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[org.clojure/clojure "1.11.0"]
+  :dependencies [[com.google.guava/guava "30.1-jre"]
+                 [org.clojure/clojure "1.11.0"]
                  [aleph "0.4.6"]
                  [cheshire "5.10.2"]
                  [jepsen "0.2.6"]

--- a/jepsen.fuzz_dist/src/fuzz_dist/checker/pn_counter.clj
+++ b/jepsen.fuzz_dist/src/fuzz_dist/checker/pn_counter.clj
@@ -1,0 +1,81 @@
+(ns fuzz-dist.checker.pn-counter
+  "Currently a clone of Jepsen's Maelstrom pn-counter.
+
+  Intent is to envolve more capabilities over time.
+  
+  An eventually-consistent counter which supports increments and decrements.
+  Validates that the final read on each node has a value which is the sum of
+  all known (or possible) increments and decrements."
+  (:require [jepsen.checker :as checker]
+            [knossos.op :as op]
+            [slingshot.slingshot :refer [try+ throw+]])
+  (:import (com.google.common.collect Range
+                                      RangeSet
+                                      TreeRangeSet)))
+
+(defn range->vec
+  "Converts an open range into a closed integer [lower upper] pair."
+  [^Range r]
+  [(inc (.lowerEndpoint r))
+   (dec (.upperEndpoint r))])
+
+(defn acceptable->vecs
+  "Turns an acceptable TreeRangeSet into a vector of [lower upper] inclusive
+  ranges."
+  [^TreeRangeSet s]
+  (map range->vec (.asRanges s)))
+
+(defn acceptable-range
+  "Takes a lower and upper bound for a range and constructs a Range for an
+  acceptable TreeRangeSet. The constructed range will be an *open* range from
+  lower - 1 to upper + 1, which ensures that merges work correctly."
+  [lower upper]
+  (Range/open (dec lower) (inc upper)))
+
+(defn checker
+  "This checker verifies that every final read is the sum of all
+  known-completed adds plus any number of possibly-completed adds. Returns a
+  map with :valid? true if all reads marked :final? are in the acceptable set.
+  Returns the acceptable set, encoded as a sequence of [lower upper] closed
+  ranges."
+  []
+  (reify checker/Checker
+    (check [this test history opts]
+      (let [; First, let's get all the add operations
+            adds (filter (comp #{:add} :f) history)
+            ; What's the total of the ops we *definitely* know happened?
+            definite-sum (->> adds
+                              (filter op/ok?)
+                              (map :value)
+                              (reduce +))
+            ; What are all the possible outcomes of indeterminate ops?
+            acceptable (TreeRangeSet/create)
+            _ (.add acceptable (acceptable-range definite-sum definite-sum))
+            ; For each possible add, we want to allow that either to happen or
+            ; not.
+            _ (doseq [add adds]
+                (when (op/info? add)
+                  (let [delta (:value add)]
+                    ; For each range, add delta, and merge that back in. Note
+                    ; we materialize asRanges to avoid iterating during our
+                    ; mutation.
+                    (doseq [^Range r (vec (.asRanges acceptable))]
+                      (.add acceptable
+                            (Range/open (+ (.lowerEndpoint r) delta)
+                                        (+ (.upperEndpoint r) delta)))))))
+            ; Now, extract the final reads for each node
+            reads (->> history
+                       (filter :final?)
+                       (filter op/ok?))
+            ; And find any problems
+            errors (->> reads
+                        (filter (fn [r]
+                                  ; If we get a fractional read for some
+                                  ; reason, our cute open-range technique is
+                                  ; gonna give wrong answers
+                                  (assert (integer? (:value r)))
+                                  (not (.contains acceptable (:value r))))))]
+        {:valid?      (empty? errors)
+         :errors      (seq errors)
+         :final-reads (map :value reads)
+         :acceptable  (acceptable->vecs acceptable)}))))

--- a/jepsen.fuzz_dist/src/fuzz_dist/checker/pn_counter.clj
+++ b/jepsen.fuzz_dist/src/fuzz_dist/checker/pn_counter.clj
@@ -38,6 +38,12 @@
   map with :valid? true if all reads marked :final? are in the acceptable set.
   Returns the acceptable set, encoded as a sequence of [lower upper] closed
   ranges."
+  ; TODO
+  ;   :linearizable? or only check :final? reads
+  ;   try keeping track of current & possible counter value to
+  ;     verify valid read
+  ;     track read staleness, delta from current/possible, chart
+  ;   bounded counter
   []
   (reify checker/Checker
     (check [this test history opts]

--- a/jepsen.fuzz_dist/src/fuzz_dist/core.clj
+++ b/jepsen.fuzz_dist/src/fuzz_dist/core.clj
@@ -2,7 +2,9 @@
   (:require
    [clojure.string :as str]
    [fuzz-dist.db :as db]
-   [fuzz-dist.workload [g-set :as g-set]]
+   [fuzz-dist.workload
+    [g-set :as g-set]
+    [pn-counter :as pn-counter]]
    [jepsen
     [cli :as cli]
     [checker :as checker]
@@ -14,7 +16,8 @@
 
 (def workloads
   "A map of workload names to functions that construct workloads, given opts."
-  {:g-set g-set/workload})
+  {:g-set      g-set/workload
+   :pn-counter pn-counter/workload})
 
 (def nemeses
   "The types of faults our nemesis can produce"

--- a/jepsen.fuzz_dist/src/fuzz_dist/workload/pn_counter.clj
+++ b/jepsen.fuzz_dist/src/fuzz_dist/workload/pn_counter.clj
@@ -1,137 +1,78 @@
-(ns maelstrom.workload.pn-counter
+(ns fuzz-dist.workload.pn-counter
   "An eventually-consistent counter which supports increments and decrements.
   Validates that the final read on each node has a value which is the sum of
-  all known (or possible) increments and decrements.
+  all known (or possible) increments and decrements."
+  (:require [fuzz-dist
+             [checker.pn-counter :as pn-counter]
+             [client :as fd-client]]
+            [jepsen.generator :as gen]
+            [slingshot.slingshot :refer [try+ throw+]]))
 
-  See also: g-counter, which is identical, but does not allow decrements."
-  (:refer-clojure :exclude [read])
-  (:require [maelstrom [client :as c]
-                       [net :as net]]
-            [jepsen [checker :as checker]
-                    [client :as client]
-                    [generator :as gen]]
-            [knossos.op :as op]
-            [schema.core :as s]
-            [slingshot.slingshot :refer [try+ throw+]])
-  (:import (com.google.common.collect Range
-                                      RangeSet
-                                      TreeRangeSet)))
+(defn pn-counter-adds []
+  (fn [] {:type :invoke, :f :add, :value (- (rand-int 10) 5)}))
 
-(c/defrpc add!
-  "Adds a (potentially negative) integer, called `delta`, to the counter.
-  Servers should respond with an `add_ok` message."
-  {:type  (s/eq "add")
-   :delta s/Int}
-  {:type  (s/eq "add_ok")})
+(defn pn-counter-reads [final?]
+  (if final?
+    (repeat {:type :invoke, :f :read, :final? true, :value nil})
+    (repeat {:type :invoke, :f :read, :value nil})))
 
-(c/defrpc read
-  "Reads the current value of the counter. Servers respond with a `read_ok`
-  message containing a `value`, which should be the sum of all (known) added
-  deltas."
-  {:type (s/eq "read")}
-  {:type (s/eq "read_ok")
-   :value s/Int})
+(defrecord PNCounterClient [conn]
+  client/Client
+  (open! [this test node]
+    (info "PNCounterClient/open" (fd-client/node-url node))
+    (assoc this :conn (fd-client/get-ws-conn fd-client/node-url node)))
 
-(defn client
-  ([net]
-   (client net nil nil))
-  ([net conn node]
-   (reify client/Client
-     (open! [this test node]
-       (client net (c/open! net) node))
+  (setup! [this test])
 
-     (setup! [this test])
+  (invoke! [_ test op]
+    (case (:f op)
+      :add  (let [resp (fd-client/ws-invoke conn :pn_counter :add op)]
+              (case (:type resp)
+                "ok"   (assoc op :type :ok)
+                "fail" (assoc op :type :fail, :error (:error resp))
+                "info" (assoc op :type :info, :error (:error resp))
+                (assoc op :type :info, :error (str resp))))
+      :read (let [resp (fd-client/ws-invoke conn :pn_counter :read op)]
+              (case (:type resp)
+                "ok"   (assoc op :type :ok,   :value (:value resp))
+                "fail" (assoc op :type :fail, :error (:error resp))
+                "info" (assoc op :type :info, :error (:error resp))
+                (assoc op :type :info, :error (str resp))))))
 
-     (invoke! [_ test op]
-       (case (:f op)
-         :add (do (add! conn node {:delta (:value op)})
-                  (assoc op :type :ok))
+  (teardown! [this test])
 
-         :read (->> (read conn node {})
-                    :value
-                    long
-                    (assoc op :type :ok, :value))))
-
-     (teardown! [_ test])
-
-     (close! [_ test]
-       (c/close! conn)))))
-
-(defn range->vec
-  "Converts an open range into a closed integer [lower upper] pair."
-  [^Range r]
-  [(inc (.lowerEndpoint r))
-   (dec (.upperEndpoint r))])
-
-(defn acceptable->vecs
-  "Turns an acceptable TreeRangeSet into a vector of [lower upper] inclusive
-  ranges."
-  [^TreeRangeSet s]
-  (map range->vec (.asRanges s)))
-
-(defn acceptable-range
-  "Takes a lower and upper bound for a range and constructs a Range for an
-  acceptable TreeRangeSet. The constructed range will be an *open* range from
-  lower - 1 to upper + 1, which ensures that merges work correctly."
-  [lower upper]
-  (Range/open (dec lower) (inc upper)))
-
-(defn checker
-  "This checker verifies that every final read is the sum of all
-  known-completed adds plus any number of possibly-completed adds. Returns a
-  map with :valid? true if all reads marked :final? are in the acceptable set.
-  Returns the acceptable set, encoded as a sequence of [lower upper] closed
-  ranges."
-  []
-  (reify checker/Checker
-    (check [this test history opts]
-      (let [; First, let's get all the add operations
-            adds (filter (comp #{:add} :f) history)
-            ; What's the total of the ops we *definitely* know happened?
-            definite-sum (->> adds
-                              (filter op/ok?)
-                              (map :value)
-                              (reduce +))
-            ; What are all the possible outcomes of indeterminate ops?
-            acceptable (TreeRangeSet/create)
-            _ (.add acceptable (acceptable-range definite-sum definite-sum))
-            ; For each possible add, we want to allow that either to happen or
-            ; not.
-            _ (doseq [add adds]
-                (when (op/info? add)
-                  (let [delta (:value add)]
-                    ; For each range, add delta, and merge that back in. Note
-                    ; we materialize asRanges to avoid iterating during our
-                    ; mutation.
-                    (doseq [^Range r (vec (.asRanges acceptable))]
-                      (.add acceptable
-                            (Range/open (+ (.lowerEndpoint r) delta)
-                                        (+ (.upperEndpoint r) delta)))))))
-            ; Now, extract the final reads for each node
-            reads (->> history
-                       (filter :final?)
-                       (filter op/ok?))
-            ; And find any problems
-            errors (->> reads
-                        (filter (fn [r]
-                                  ; If we get a fractional read for some
-                                  ; reason, our cute open-range technique is
-                                  ; gonna give wrong answers
-                                  (assert (integer? (:value r)))
-                                  (not (.contains acceptable (:value r))))))]
-        {:valid?      (empty? errors)
-         :errors      (seq errors)
-         :final-reads (map :value reads)
-         :acceptable  (acceptable->vecs acceptable)}))))
+  (close! [_ test]
+    (s/close! conn)))
 
 (defn workload
-  "Constructs a workload for a grow-only set, given options from the CLI
-  test constructor:
-
-      {:net     A Maelstrom network}"
+  "Constructs a workload, {:client, :preamble-generator, :generator, :final-generator, :checker},
+   for a pn-counter, given options from the CLI test constructor."
   [opts]
-  {:client          (client (:net opts))
-   :generator       (gen/mix [(fn [] {:f :add, :value (- (rand-int 10) 5)})
-                              (repeat {:f :read})])
-   :final-generator (gen/each-thread {:f :read, :final? true})
-   :checker         (checker)})
+  {:client (PNCounterClient. nil)
+   :preamble-generator (->> (gen/mix [(pn-counter-adds)
+                                      (pn-counter-reads false)])
+                            (gen/stagger (/ (count (:nodes opts))))
+                            (gen/time-limit 5)
+                            (gen/clients))
+   :generator (gen/mix [(pn-counter-adds)
+                        (pn-counter-reads false)])
+   :final-generator (gen/phases
+                     ;; a simple sequence of transactions to help clarify end state and final reads
+                     (gen/log "Final adds/reads in healed state...")
+                     (->>
+                      (gen/mix [(pn-counter-adds)
+                                (pn-counter-reads false)])
+                      (gen/stagger (/ 1))
+                      (gen/time-limit 10)
+                      (gen/clients))
+
+                     (gen/log "Let database quiesce...")
+                     (gen/sleep 10)
+
+                     (gen/log "Final read...")
+                     (->>
+                      (pn-counter-reads true)
+                      (gen/once)
+                      (gen/each-thread)
+                      (gen/clients)))
+   :checker (pn-counter/checker)})

--- a/jepsen.fuzz_dist/src/fuzz_dist/workload/pn_counter.clj
+++ b/jepsen.fuzz_dist/src/fuzz_dist/workload/pn_counter.clj
@@ -1,0 +1,137 @@
+(ns maelstrom.workload.pn-counter
+  "An eventually-consistent counter which supports increments and decrements.
+  Validates that the final read on each node has a value which is the sum of
+  all known (or possible) increments and decrements.
+
+  See also: g-counter, which is identical, but does not allow decrements."
+  (:refer-clojure :exclude [read])
+  (:require [maelstrom [client :as c]
+                       [net :as net]]
+            [jepsen [checker :as checker]
+                    [client :as client]
+                    [generator :as gen]]
+            [knossos.op :as op]
+            [schema.core :as s]
+            [slingshot.slingshot :refer [try+ throw+]])
+  (:import (com.google.common.collect Range
+                                      RangeSet
+                                      TreeRangeSet)))
+
+(c/defrpc add!
+  "Adds a (potentially negative) integer, called `delta`, to the counter.
+  Servers should respond with an `add_ok` message."
+  {:type  (s/eq "add")
+   :delta s/Int}
+  {:type  (s/eq "add_ok")})
+
+(c/defrpc read
+  "Reads the current value of the counter. Servers respond with a `read_ok`
+  message containing a `value`, which should be the sum of all (known) added
+  deltas."
+  {:type (s/eq "read")}
+  {:type (s/eq "read_ok")
+   :value s/Int})
+
+(defn client
+  ([net]
+   (client net nil nil))
+  ([net conn node]
+   (reify client/Client
+     (open! [this test node]
+       (client net (c/open! net) node))
+
+     (setup! [this test])
+
+     (invoke! [_ test op]
+       (case (:f op)
+         :add (do (add! conn node {:delta (:value op)})
+                  (assoc op :type :ok))
+
+         :read (->> (read conn node {})
+                    :value
+                    long
+                    (assoc op :type :ok, :value))))
+
+     (teardown! [_ test])
+
+     (close! [_ test]
+       (c/close! conn)))))
+
+(defn range->vec
+  "Converts an open range into a closed integer [lower upper] pair."
+  [^Range r]
+  [(inc (.lowerEndpoint r))
+   (dec (.upperEndpoint r))])
+
+(defn acceptable->vecs
+  "Turns an acceptable TreeRangeSet into a vector of [lower upper] inclusive
+  ranges."
+  [^TreeRangeSet s]
+  (map range->vec (.asRanges s)))
+
+(defn acceptable-range
+  "Takes a lower and upper bound for a range and constructs a Range for an
+  acceptable TreeRangeSet. The constructed range will be an *open* range from
+  lower - 1 to upper + 1, which ensures that merges work correctly."
+  [lower upper]
+  (Range/open (dec lower) (inc upper)))
+
+(defn checker
+  "This checker verifies that every final read is the sum of all
+  known-completed adds plus any number of possibly-completed adds. Returns a
+  map with :valid? true if all reads marked :final? are in the acceptable set.
+  Returns the acceptable set, encoded as a sequence of [lower upper] closed
+  ranges."
+  []
+  (reify checker/Checker
+    (check [this test history opts]
+      (let [; First, let's get all the add operations
+            adds (filter (comp #{:add} :f) history)
+            ; What's the total of the ops we *definitely* know happened?
+            definite-sum (->> adds
+                              (filter op/ok?)
+                              (map :value)
+                              (reduce +))
+            ; What are all the possible outcomes of indeterminate ops?
+            acceptable (TreeRangeSet/create)
+            _ (.add acceptable (acceptable-range definite-sum definite-sum))
+            ; For each possible add, we want to allow that either to happen or
+            ; not.
+            _ (doseq [add adds]
+                (when (op/info? add)
+                  (let [delta (:value add)]
+                    ; For each range, add delta, and merge that back in. Note
+                    ; we materialize asRanges to avoid iterating during our
+                    ; mutation.
+                    (doseq [^Range r (vec (.asRanges acceptable))]
+                      (.add acceptable
+                            (Range/open (+ (.lowerEndpoint r) delta)
+                                        (+ (.upperEndpoint r) delta)))))))
+            ; Now, extract the final reads for each node
+            reads (->> history
+                       (filter :final?)
+                       (filter op/ok?))
+            ; And find any problems
+            errors (->> reads
+                        (filter (fn [r]
+                                  ; If we get a fractional read for some
+                                  ; reason, our cute open-range technique is
+                                  ; gonna give wrong answers
+                                  (assert (integer? (:value r)))
+                                  (not (.contains acceptable (:value r))))))]
+        {:valid?      (empty? errors)
+         :errors      (seq errors)
+         :final-reads (map :value reads)
+         :acceptable  (acceptable->vecs acceptable)}))))
+
+(defn workload
+  "Constructs a workload for a grow-only set, given options from the CLI
+  test constructor:
+
+      {:net     A Maelstrom network}"
+  [opts]
+  {:client          (client (:net opts))
+   :generator       (gen/mix [(fn [] {:f :add, :value (- (rand-int 10) 5)})
+                              (repeat {:f :read})])
+   :final-generator (gen/each-thread {:f :read, :final? true})
+   :checker         (checker)})


### PR DESCRIPTION
Uses AntidoteDB `antidote_crdt_counter_pn` data type.

Uses Jepsen checker from Maelstron.

Initial full end-to-end impl.
Intent is to enhance checker.